### PR TITLE
LZODF creating external tables and with proper column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project depends of lzo support enabled in your cluster, the instructions ar
 For use this class, you need to follow the instructions below:
 
 ```
-l2s <lzo file location> <parquet file destination> <original_table_name> <delimiter> 
+l2s <lzo file location> <parquet/snappy file destination> <original table name> [delimiter] 
 ```
 
 Where: 
@@ -25,12 +25,12 @@ Where:
 - `<lzo file location>` : Where lzo files are located
 - `<parquet/snappy file destination>` : What is the location are new files need to be placed
 - `<original table name>` : The name of the original table
-- `<delimiter>` : The delimiter used to create the original table
+- `[delimiter]` : The delimiter used to create the original table. Optional, defaults to ','
 
 RDD execution example:
 
 ```
-$ spark-submit --class br.com.brainboss.lzordd.lzordd l2s.jar /user/hive/warehouse/hive_lzo /user/hive/warehouse/snappy_test hive_lzo ,
+$ spark-submit --class br.com.brainboss.lzordd.lzordd l2s.jar /user/hive/warehouse/hive_lzo /user/hive/warehouse/hive_lzo_snappy hive_lzo ,
 ```
 
 ### Dataframe strategy
@@ -38,16 +38,16 @@ $ spark-submit --class br.com.brainboss.lzordd.lzordd l2s.jar /user/hive/warehou
 For use this class, you need to follow the instructions below:
 
 ```
-l2s <lzo file location> <table destination>
+l2s <parquet/snappy file destination> <original table name>
 ```
 
 Where: 
 
-- `<lzo file location>` : Where lzo files are located
-- `<table destination>` : What is the location are new files need to be placed
+- `<parquet/snappy file destination>` : What is the location are new files need to be placed
+- `<original table name>` : The name of the original table
 
 Dataframe execution example: 
 
 ```
-$ spark-submit --class br.com.brainboss.lzodf.lzodf l2s.jar /user/hive/warehouse/hive_lzo snappy_hive_lzo
+$ spark-submit --class br.com.brainboss.lzodf.lzodf l2s.jar /user/hive/warehouse/hive_lzo_snappy hive_lzo
 ``` 

--- a/src/main/scala/br/com/brainboss/lzodf/lzodf.scala
+++ b/src/main/scala/br/com/brainboss/lzodf/lzodf.scala
@@ -3,20 +3,32 @@ package br.com.brainboss.lzodf
 import org.apache.spark.sql.SparkSession
 
 object lzodf extends App {
-  val spark = SparkSession.builder().appName("lzodf").getOrCreate()
+  val usage = """
+    Usage: lzodf <input-path> <output-path> <table name> [delimiter]
+  """
 
-  val inputPath = args(0)
-  val outputPath = args(1)
+  if (args.length < 3)
+    println(usage)
+  else {
+    val spark = SparkSession.builder().appName("lzodf").getOrCreate()
 
-  //spark.conf.set("spark.sql.parquet.compression.codec","codec")
-  val df = spark.read.csv(inputPath)
+    val inputPath = args(0)
+    val outputPath = args(1)
+    val tableName = args(2)
+    val delimiter = if (args.length == 4) args(3) else ","
 
-  df.show(10)
+    val df = spark
+      .read
+      .option("delimiter", delimiter)
+      .csv(inputPath)
 
-  df
-    .write.mode(org.apache.spark.sql.SaveMode.Overwrite)
-    .option("compression", "snappy")
-    .format("parquet")
-    .saveAsTable(outputPath)
+    df.show(10)
 
+    df
+      .write.mode(org.apache.spark.sql.SaveMode.Overwrite)
+      .option("compression", "snappy")
+      .option("path", outputPath)
+      .format("parquet")
+      .saveAsTable(tableName)
+  }
 }

--- a/src/main/scala/br/com/brainboss/lzodf/lzodf.scala
+++ b/src/main/scala/br/com/brainboss/lzodf/lzodf.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.SparkSession
 
 object lzodf extends App {
   val usage = """
-    Usage: lzodf <input-path> <output-path> <table name> [delimiter]
+    Usage: lzodf <source table name> <output-path> <parquet table name>
   """
 
   if (args.length < 3)
@@ -12,15 +12,11 @@ object lzodf extends App {
   else {
     val spark = SparkSession.builder().appName("lzodf").getOrCreate()
 
-    val inputPath = args(0)
+    val srcTableName = args(0)
     val outputPath = args(1)
     val tableName = args(2)
-    val delimiter = if (args.length == 4) args(3) else ","
 
-    val df = spark
-      .read
-      .option("delimiter", delimiter)
-      .csv(inputPath)
+    val df = spark.sql(s"SELECT * FROM ${srcTableName}")
 
     df.show(10)
 

--- a/src/main/scala/br/com/brainboss/lzodf/lzodf.scala
+++ b/src/main/scala/br/com/brainboss/lzodf/lzodf.scala
@@ -4,27 +4,24 @@ import org.apache.spark.sql.SparkSession
 
 object lzodf extends App {
   val usage = """
-    Usage: lzodf <source table name> <output-path> <parquet table name>
+    Usage: lzodf <parquet/snappy file destination> <original table name>
   """
 
-  if (args.length < 3)
+  if (args.length < 2)
     println(usage)
   else {
     val spark = SparkSession.builder().appName("lzodf").getOrCreate()
 
-    val srcTableName = args(0)
-    val outputPath = args(1)
-    val tableName = args(2)
+    val outputPath = args(0)
+    val tableName = args(1)
 
-    val df = spark.sql(s"SELECT * FROM ${srcTableName}")
-
-    df.show(10)
+    val df = spark.sql(s"SELECT * FROM ${tableName}")
 
     df
       .write.mode(org.apache.spark.sql.SaveMode.Overwrite)
       .option("compression", "snappy")
       .option("path", outputPath)
       .format("parquet")
-      .saveAsTable(tableName)
+      .saveAsTable(s"${tableName}_snappy")
   }
 }

--- a/src/main/scala/br/com/brainboss/lzodf/package.scala
+++ b/src/main/scala/br/com/brainboss/lzodf/package.scala
@@ -1,5 +1,0 @@
-package br.com.brainboss
-
-package object lzodf {
-
-}

--- a/src/main/scala/br/com/brainboss/lzordd/lzordd.scala
+++ b/src/main/scala/br/com/brainboss/lzordd/lzordd.scala
@@ -3,28 +3,32 @@ package br.com.brainboss.lzordd
 import org.apache.spark.sql.SparkSession
 
 object lzordd extends App {
-      val spark = SparkSession.builder().appName("lzordd").getOrCreate()
-      val sc = spark.sparkContext
+  val usage = """
+    Usage: lzordd <input-path> <output-path> <table name> [delimiter]
+  """
 
-      val usage = """
-            Usage: lzordd <input-path> <output-path> <table name> [delimiter]
-      """
+  if (args.length < 3)
+    println(usage)
+  else {
+    val spark = SparkSession.builder().appName("lzordd").getOrCreate()
+    val sc = spark.sparkContext
 
-      if (args.length < 3) println(usage)
-      val inputPath = args(0)
-      val outputPath = args(1)
-      val tableName = args(2)
-      val delimiter = if (args.length == 4) args(3) else null
+    val inputPath = args(0)
+    val outputPath = args(1)
+    val tableName = args(2)
+    val delimiter = if (args.length == 4) args(3) else ","
 
-      // TODO: Need to catch the correct exceptions
-      try {
+    // TODO: Need to catch the correct exceptions
+    try {
 
-            val read = readLzo(sc, inputPath, delimiter)
-            val tableSchema = createAndWriteSnappy(spark, tableName, read, outputPath)
+      val read = readLzo(sc, inputPath, delimiter)
+      val tableSchema = createAndWriteSnappy(spark, tableName, read, outputPath)
 
-            readAndCreateTable(spark, tableSchema, tableName, outputPath)
+      readAndCreateTable(spark, tableSchema, tableName, outputPath)
 
-      } catch { case e:Exception=>e.printStackTrace() }
-
+    } catch {
+      case e: Exception => e.printStackTrace()
+    }
+  }
 }
 

--- a/src/main/scala/br/com/brainboss/lzordd/lzordd.scala
+++ b/src/main/scala/br/com/brainboss/lzordd/lzordd.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.SparkSession
 
 object lzordd extends App {
   val usage = """
-    Usage: lzordd <input-path> <output-path> <table name> [delimiter]
+    Usage: lzordd <lzo file location> <parquet/snappy file destination> <original table name> [delimiter]
   """
 
   if (args.length < 3)

--- a/src/main/scala/br/com/brainboss/lzordd/package.scala
+++ b/src/main/scala/br/com/brainboss/lzordd/package.scala
@@ -24,7 +24,6 @@ package object lzordd {
       classOf[org.apache.hadoop.io.Text])
 
     println(s"Input LZO from: $inputPath")
-
     // Split text by delimiter
     files.map(_._2.toString.split(delimiter))
   }


### PR DESCRIPTION
LZODF strategy was creating managed tables with generic column names (_c0, _c1, _c2...). Now it's cerating external tables with proper column names (same as original table).

Also, updated documentation to be in compliance with the code modifications.